### PR TITLE
Add prefix-aware randomKey API; docs, tests, benches

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ While both backends are optimized for performance and suitable for most load tes
   
 - `get(key: string): Promise<any>`
   - Retrieves a value by key. Throws if key doesn't exist.
-  
+
+- `randomKey(options?: RandomKeyOptions): Promise<string>`
+  - Returns a random key, optionally filtered by `{ prefix }`.
+
 - `delete(key: string): Promise<void>`
   - Removes a key-value pair.
 
@@ -140,6 +143,13 @@ While both backends are optimized for performance and suitable for most load tes
   
 - `size(): number`
   - Returns current store size.
+
+### RandomKeyOptions Interface
+```typescript
+interface RandomKeyOptions {
+    prefix?: string;  // Optional prefix filter
+}
+```
 
 ### ListOptions Interface
 ```typescript

--- a/kv/store/memory_benchmark_test.go
+++ b/kv/store/memory_benchmark_test.go
@@ -28,6 +28,44 @@ func BenchmarkMemoryStore_Get(b *testing.B) {
 	}
 }
 
+func BenchmarkMemoryStore_RandomKey(b *testing.B) {
+	store := NewMemoryStore()
+
+	// Setup: Add some data to the store
+	for i := range 10_000 {
+		_ = store.Set(fmt.Sprintf("key-%d", i), "v")
+	}
+
+	// Reset the timer before the actual benchmark
+	b.ResetTimer()
+
+	// Run the benchmark
+	for range b.N {
+		_, _ = store.RandomKey("")
+	}
+}
+
+func BenchmarkMemoryStore_RandomKey_WithPrefix(b *testing.B) {
+	store := NewMemoryStore()
+
+	// Setup: Add some data to the store
+	for i := range 10_000 {
+		_ = store.Set(fmt.Sprintf("key-%d", i), "v")
+
+		if i < 2_000 {
+			_ = store.Set(fmt.Sprintf("pfx-%d", i), "v")
+		}
+	}
+
+	// Reset the timer before the actual benchmark
+	b.ResetTimer()
+
+	// Run the benchmark
+	for range b.N {
+		_, _ = store.RandomKey("pfx-")
+	}
+}
+
 func BenchmarkMemoryStore_Set(b *testing.B) {
 	store := NewMemoryStore()
 

--- a/kv/store/serialized_store.go
+++ b/kv/store/serialized_store.go
@@ -41,6 +41,12 @@ func (s *SerializedStore) Get(key string) (any, error) {
 	return rawValue, nil
 }
 
+// RandomKey returns a random key optionally filtered by prefix.
+// It returns "" and nil when the store is empty or when no keys match.
+func (s *SerializedStore) RandomKey(prefix string) (string, error) {
+	return s.store.RandomKey(prefix)
+}
+
 // Set serializes a value and stores it.
 func (s *SerializedStore) Set(key string, value any) error {
 	// Serialize the value

--- a/kv/store/store.go
+++ b/kv/store/store.go
@@ -6,6 +6,10 @@ type Store interface {
 	// Get returns the value of a key in the store.
 	Get(key string) (any, error)
 
+	// RandomKey returns a random key optionally filtered by prefix.
+	// It returns "" and nil when the store is empty or when no keys match.
+	RandomKey(prefix string) (string, error)
+
 	// Set sets the value of a key in the store.
 	Set(key string, value any) error
 


### PR DESCRIPTION
Hey, Theo.
I split my feature into two smaller ones, as we agreed in the last PR.
I added the ability to get a random key, it is often a very useful function in load tests.
For now this is done without key caching and benchmarks show low speed on my Ryzen 9 9950X and 1 TB SSD drive.
The next PR with a key caching mechanism will be based on this PR.