### PR TITLE
Bug fixes and dead-code purge (precedes structural refactor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- **Disk backend bucket name regression.** The BoltDB bucket name has been corrected to `k6` (the original value used prior to the in-memory backend refactor). Versions that shipped after the regression used the database file path (`.k6.kv`) as the bucket name, which made data inaccessible to clients expecting the documented `k6` bucket.
+
+  If you have an existing `.k6.kv` file created with a regressed version, its contents are stored in a bucket named `.k6.kv` and will not be visible to this release. Delete the `.k6.kv` file to start fresh.

--- a/examples/list.js
+++ b/examples/list.js
@@ -11,7 +11,7 @@ export default async function () {
     await kv.set("abc", 123);
     await kv.set("easy as", [1, 2, 3]);
     await kv.set("a b c", { "123": "baby you and me girl"});
-    console.log(`current size of the KV store: ${kv.size()}`)
+    console.log(`current size of the KV store: ${await kv.size()}`)
 
     const entries = await kv.list({ prefix: "a" });
     for (const entry of entries) {

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -236,22 +236,17 @@ type ListOptions struct {
 
 	// Limit is the maximum number of entries to return.
 	Limit int64 `json:"limit"`
-
-	limitSet bool
 }
 
 // ImportListOptions instantiates a ListOptions from a sobek.Value.
 func ImportListOptions(rt *sobek.Runtime, options sobek.Value) ListOptions {
 	listOptions := ListOptions{}
 
-	// If no options are passed, return the default options
 	if common.IsNullish(options) {
 		return listOptions
 	}
 
-	// Interpret the options as an object
 	optionsObj := options.ToObject(rt)
-
 	listOptions.Prefix = optionsObj.Get("prefix").String()
 
 	limitValue := optionsObj.Get("limit")
@@ -260,10 +255,8 @@ func ImportListOptions(rt *sobek.Runtime, options sobek.Value) ListOptions {
 	}
 
 	var limit int64
-	err := rt.ExportTo(limitValue, &limit)
-	if err == nil {
+	if err := rt.ExportTo(limitValue, &limit); err == nil {
 		listOptions.Limit = limit
-		listOptions.limitSet = true
 	}
 
 	return listOptions

--- a/kv/module.go
+++ b/kv/module.go
@@ -1,10 +1,10 @@
-// Package kv provides a key-value database that can be used to store and retrieve data.
+// Package kv provides a key-value store JS module that can be used to share state across
+// k6 Virtual Users during a test run.
 //
-// The key-value database is backed by BoltDB, and is shared between all VUs. It is persisted
-// to disk, so data stored in the database will be available across test runs.
-//
-// The database is opened when the first KV instance is created, and closed when the last KV
-// instance is closed.
+// The store is shared between all VUs and constructed once on the first call to openKv().
+// Two backends are available: an in-memory backend (ephemeral, fastest) and a disk backend
+// (BoltDB-backed, persistent across test runs). The backend and serialization format are
+// selected via the options passed to openKv().
 package kv
 
 import (
@@ -21,7 +21,6 @@ type (
 	// RootModule is the global module instance that will create Client
 	// instances for each VU.
 	RootModule struct {
-		// db *db
 		store store.Store
 	}
 
@@ -29,8 +28,6 @@ type (
 	ModuleInstance struct {
 		vu modules.VU
 		rm *RootModule
-
-		kv *KV
 	}
 )
 
@@ -40,19 +37,12 @@ var (
 	_ modules.Module   = &RootModule{}
 )
 
-// New returns a pointer to a new RootModule instance
+// New returns a pointer to a new RootModule instance.
+//
+// The shared store is left nil and is constructed on the first call to openKv()
+// from JS, so its backend and serialization can be chosen at script time.
 func New() *RootModule {
-	// // Create a memory store with JSON serialization by default
-	// memoryStore := store.NewMemoryStore()
-	// jsonSerializer := store.NewJSONSerializer()
-	// serializedStore := store.NewSerializedStore(memoryStore, jsonSerializer)
-
-	// return &RootModule{store: serializedStore}
-	return &RootModule{
-		// As default, the store is nil, we expect the user to call openKv()
-		// which should set the store shared between all VUs.
-		store: nil,
-	}
+	return &RootModule{}
 }
 
 // NewModuleInstance implements the modules.Module interface and returns
@@ -70,12 +60,6 @@ func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{Named: map[string]any{
 		"openKv": mi.OpenKv,
 	}}
-}
-
-// NewKV implements the modules.Instance interface and returns
-// a new KV instance.
-func (mi *ModuleInstance) NewKV(_ sobek.ConstructorCall) *sobek.Object {
-	return mi.vu.Runtime().ToValue(mi.kv).ToObject(mi.vu.Runtime())
 }
 
 // OpenKv opens the KV store and returns a KV instance.
@@ -108,14 +92,11 @@ func (mi *ModuleInstance) OpenKv(opts sobek.Value) *sobek.Object {
 		}
 
 		// Create a serialized store with the chosen store and serializer
-		serializedStore := store.NewSerializedStore(baseStore, serializer)
-		mi.rm.store = serializedStore
+		mi.rm.store = store.NewSerializedStore(baseStore, serializer)
 	}
 
 	kv := NewKV(mi.vu, mi.rm.store)
-	mi.kv = kv
-
-	return mi.vu.Runtime().ToValue(mi.kv).ToObject(mi.vu.Runtime())
+	return mi.vu.Runtime().ToValue(kv).ToObject(mi.vu.Runtime())
 }
 
 // Options represents the options for a KV instance.

--- a/kv/store/disk.go
+++ b/kv/store/disk.go
@@ -61,7 +61,7 @@ func (s *DiskStore) open() error {
 	}
 
 	err = handler.Update(func(tx *bolt.Tx) error {
-		_, bucketErr := tx.CreateBucketIfNotExists([]byte(DefaultDiskStorePath))
+		_, bucketErr := tx.CreateBucketIfNotExists([]byte(DefaultKvBucket))
 		if bucketErr != nil {
 			return fmt.Errorf("failed to create internal bucket: %w", bucketErr)
 		}
@@ -73,7 +73,7 @@ func (s *DiskStore) open() error {
 	}
 
 	s.handle = handler
-	s.bucket = []byte(DefaultDiskStorePath)
+	s.bucket = []byte(DefaultKvBucket)
 	s.opened.Store(true)
 	s.refCount.Add(1)
 

--- a/kv/store/serialized_store.go
+++ b/kv/store/serialized_store.go
@@ -115,13 +115,3 @@ func (s *SerializedStore) List(prefix string, limit int64) ([]Entry, error) {
 func (s *SerializedStore) Close() error {
 	return s.store.Close()
 }
-
-// GetSerializer returns the serializer used by this store.
-func (s *SerializedStore) GetSerializer() Serializer {
-	return s.serializer
-}
-
-// SetSerializer changes the serializer used by this store.
-func (s *SerializedStore) SetSerializer(serializer Serializer) {
-	s.serializer = serializer
-}

--- a/kv/store/serializer.go
+++ b/kv/store/serializer.go
@@ -35,15 +35,16 @@ func (s *JSONSerializer) Serialize(value any) ([]byte, error) {
 }
 
 // Deserialize converts a JSON byte slice back to a value.
+//
+// Empty input is treated as the absence of a value, surfaced to callers as
+// a JS-side null with no error — empty bytes are a legitimate stored value.
 func (s *JSONSerializer) Deserialize(data []byte) (any, error) {
-	var err error
-
 	if len(data) == 0 {
-		return nil, err
+		return nil, nil //nolint:nilnil
 	}
 
 	var value any
-	if err = json.Unmarshal(data, &value); err != nil {
+	if err := json.Unmarshal(data, &value); err != nil {
 		return nil, fmt.Errorf("unable to deserialize JSON value: %w", err)
 	}
 	return value, nil


### PR DESCRIPTION
## Summary

Three independent fixes that prepare the ground for a follow-up structural refactor. Each commit is reviewable on its own; no functional dependencies between them.

- **`389cb19` fix(disk): restore "k6" bucket name** — PR #9 inadvertently used the database file path (`.k6.kv`) as the BoltDB bucket name, leaving `DefaultKvBucket` ("k6") dead. Restores the intended bucket name. **Behavior change for users running the regressed version:** their existing `.k6.kv` files store data under a `.k6.kv` bucket and will appear empty against this release. The new `CHANGELOG.md` documents the workaround.
- **`c501162` fix(examples): await kv.size() in list.js** — `kv.size()` returns a Promise; the unawaited template literal was logging `[object Promise]`. The other three examples were audited and are clean.
- **`a90971b` chore: purge dead code** — Removes the unreachable sobek `NewKV` constructor + `mi.kv` field, commented-out `New()` snippet, stale `// db *db` comment, stale package docstring, `SerializedStore.{Get,Set}Serializer`, `ListOptions.limitSet`, and the meaningless `var err error` in `JSONSerializer.Deserialize`. Net −35 lines.

A follow-up PR will land the structural refactor (Backend/Store interface split, `sync.Once` lifecycle, async helper, contract test harness).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -timeout 800s ./...`
- [x] `golangci-lint run` (v1.64.5, matches CI pin)
- [ ] CI green on Ubuntu + Windows (Go 1.23.x + 1.24.x)
- [ ] Manual smoke: `xk6 build --with github.com/oleiade/xk6-kv="."` then `./k6 run examples/{disk,in-memory,concurrent,list}.js`