### PR TITLE
chore: migrate golangci-lint config to v2

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.10
 
   test-go-versions:
     strategy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,73 +1,8 @@
-# v1.63.4
+# v2.10.1
 # Please don't remove the first line. It uses in CI to determine the golangci version
-run:
-  timeout: 5m
-
-issues:
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-issues-per-linter: 0
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
-  max-same-issues: 0
-
-  # We want to try and improve the comments in the k6 codebase, so individual
-  # non-golint items from the default exclusion list will gradually be added
-  # to the exclude-rules below
-  exclude-use-default: false
-
-  exclude-rules:
-   # Exclude duplicate code and function length and complexity checking in test
-   # files (due to common repeats and long functions in test code)
-   - path: _(test|gen)\.go
-     linters:
-       - canonicalheader
-       - cyclop
-       - dupl
-       - gocognit
-       - funlen
-       - lll
-       - forcetypeassert
-   - path: js\/modules\/k6\/browser\/.*\.go
-     linters:
-       - revive
-       - contextcheck
-   - path: js\/modules\/k6\/html\/.*\.go
-     text: "exported: exported "
-     linters:
-       - revive
-   - path: js\/modules\/k6\/http\/.*_test\.go
-     linters:
-       # k6/http module's tests are quite complex because they often have several nested levels.
-       # The module is in maintenance mode, so we don't intend to port the tests to a parallel version.
-       - paralleltest
-       - tparallel
-   - linters:
-     - forbidigo
-     text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'
-
-linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
-  cyclop:
-    max-complexity: 25
-  dupl:
-    threshold: 150
-  goconst:
-    min-len: 10
-    min-occurrences: 4
-  funlen:
-    lines: 80
-    statements: 60
-  forbidigo:
-    forbid:
-      - '^(fmt\\.Print(|f|ln)|print|println)$'
-      # Forbid everything in os, except os.Signal and os.SyscalError
-      - '^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?'
-      # Forbid everything in syscall except the uppercase constants
-      - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
-      - '^logrus\.Logger$'
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -94,13 +29,9 @@ linters:
     - gocognit
     - goconst
     - gocritic
-    - gofmt
-    - gofumpt
-    - goimports
     - gomoddirectives
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -108,6 +39,7 @@ linters:
     - lll
     - makezero
     - misspell
+    - modernize
     - nakedret
     - nestif
     - nilerr
@@ -119,19 +51,98 @@ linters:
     - prealloc
     - predeclared
     - promlinter
-    - revive
     - reassign
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
-    - usetesting
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
-  fast: false
+  settings:
+    cyclop:
+      max-complexity: 25
+    dupl:
+      threshold: 150
+    exhaustive:
+      default-signifies-exhaustive: true
+    forbidigo:
+      forbid:
+        - pattern: ^(fmt\\.Print(|f|ln)|print|println)$
+        - pattern: ^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?
+        - pattern: ^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?
+        - pattern: ^logrus\.Logger$
+        - pattern: ^afero\.(.*)$(# Using afero outside of the fsext package is forbidden )?
+    funlen:
+      lines: 80
+      statements: 60
+    goconst:
+      min-len: 10
+      min-occurrences: 4
+    usetesting:
+      os-setenv: true
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - canonicalheader
+          - cyclop
+          - dupl
+          - forcetypeassert
+          - funlen
+          - gocognit
+          - lll
+          - gosec
+        path: _(test|gen)\.go
+      - linters:
+          - contextcheck
+          - revive
+        path: js\/modules\/k6\/browser\/.*\.go
+      - linters:
+          - revive
+        path: js\/modules\/k6\/html\/.*\.go
+        text: 'exported: exported '
+      - linters:
+          - paralleltest
+          - tparallel
+        path: js\/modules\/k6\/html\/.*\.go
+      - linters:
+          - paralleltest
+          - tparallel
+        path: js\/modules\/k6\/http\/.*_test\.go
+      - linters:
+          - forbidigo
+        text: use of `os\.(SyscallError|Signal|Interrupt)` forbidden
+      - linters:
+          - forbidigo
+        text: use of `afero\.(.*)` forbidden
+        path: lib/fsext/.*\.go
+      - linters:
+          - revive
+        text: avoid meaningless package names
+      - linters:
+          - revive
+        text: avoid package names that conflict with Go standard library
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/kv/module.go
+++ b/kv/module.go
@@ -67,7 +67,7 @@ func (rm *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 // Exports implements the modules.Instance interface and returns
 // the exports of the JS module.
 func (mi *ModuleInstance) Exports() modules.Exports {
-	return modules.Exports{Named: map[string]interface{}{
+	return modules.Exports{Named: map[string]any{
 		"openKv": mi.OpenKv,
 	}}
 }

--- a/kv/store/disk_benchmark_test.go
+++ b/kv/store/disk_benchmark_test.go
@@ -1,4 +1,4 @@
-//nolint:forbidigo,errcheck,gosec
+//nolint:forbidigo,errcheck
 package store
 
 import (
@@ -20,7 +20,7 @@ func BenchmarkDiskStore_Get(b *testing.B) {
 	store.path = tempFile.Name()
 
 	// Setup: Add some data to the store
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
 		err := store.Set(key, value)
@@ -88,7 +88,7 @@ func BenchmarkDiskStore_Delete(b *testing.B) {
 			store.path = tempFile.Name()
 
 			// Setup: Add data to the store
-			for i := 0; i < size; i++ {
+			for i := range size {
 				key := fmt.Sprintf("key-%d", i)
 				value := fmt.Sprintf("value-%d", i)
 				err := store.Set(key, value)
@@ -134,7 +134,7 @@ func BenchmarkDiskStore_Exists(b *testing.B) {
 	store.path = tempFile.Name()
 
 	// Setup: Add some data to the store
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
 		err := store.Set(key, value)
@@ -170,7 +170,7 @@ func BenchmarkDiskStore_List(b *testing.B) {
 	store.path = tempFile.Name()
 
 	// Setup: Add some data to the store
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
 		err := store.Set(key, value)
@@ -180,7 +180,7 @@ func BenchmarkDiskStore_List(b *testing.B) {
 	}
 
 	// Add some data with a specific prefix
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		key := fmt.Sprintf("prefix-%d", i)
 		value := fmt.Sprintf("value-%d", i)
 		err := store.Set(key, value)
@@ -236,7 +236,7 @@ func BenchmarkDiskStore_Concurrent(b *testing.B) {
 	store.path = tempFile.Name()
 
 	// Setup: Add some data to the store
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
 		err := store.Set(key, value)

--- a/kv/store/disk_test.go
+++ b/kv/store/disk_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package store
 
@@ -488,7 +487,7 @@ func setupTempDiskStore(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Failed to create temporary file: %v", err)
 	}
-	tempFile.Close() //nolint:errcheck,gosec
+	tempFile.Close() //nolint:errcheck
 
 	return tempFile.Name()
 }

--- a/kv/store/memory.go
+++ b/kv/store/memory.go
@@ -100,7 +100,7 @@ func (s *MemoryStore) List(prefix string, limit int64) ([]Entry, error) {
 	}
 	sort.Strings(keys)
 
-	var entries []Entry //nolint:prealloc
+	var entries []Entry
 	var count int64
 
 	// Apply limit if set

--- a/kv/store/memory_benchmark_test.go
+++ b/kv/store/memory_benchmark_test.go
@@ -105,7 +105,7 @@ func BenchmarkMemoryStore_List(b *testing.B) {
 	store := NewMemoryStore()
 
 	// Setup: Add some data to the store
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
 		err := store.Set(key, value)

--- a/kv/store/memory_test.go
+++ b/kv/store/memory_test.go
@@ -295,14 +295,14 @@ func TestMemoryStore_Concurrency(t *testing.T) {
 	// Test concurrent reads and writes
 	go func() {
 		for range 100 {
-			store.Set("key", "value") //nolint:errcheck,gosec
+			store.Set("key", "value") //nolint:errcheck
 		}
 		done <- true
 	}()
 
 	go func() {
 		for range 100 {
-			store.Get("key") //nolint:errcheck,gosec
+			store.Get("key") //nolint:errcheck
 		}
 		done <- true
 	}()

--- a/kv/store/serializer.go
+++ b/kv/store/serializer.go
@@ -69,7 +69,7 @@ func (s *StringSerializer) Serialize(value any) ([]byte, error) {
 	}
 
 	// For other values, try to convert to string
-	return []byte(fmt.Sprintf("%v", value)), nil
+	return fmt.Appendf(nil, "%v", value), nil
 }
 
 // Deserialize converts bytes back to a string.


### PR DESCRIPTION
## Summary
- Migrate `.golangci.yml` to the v2 schema, mirroring [grafana/k6's config](https://raw.githubusercontent.com/grafana/k6/refs/heads/master/.golangci.yml) so the two stay in sync.
- Bump `golangci/golangci-lint-action` to `v7` (required for v2) and pin `version: v2.10`.
- Apply the code cleanups that the aligned config surfaces so `golangci-lint run` is green.

## Config changes
- `version: "2"`, `linters.default: none` replaces `disable-all`.
- `linters-settings` -> `linters.settings`; `issues.exclude-rules` -> `linters.exclusions.rules`.
- `gofmt`, `gofumpt`, `goimports` moved to the new `formatters` section.
- Picks up k6's `modernize` and `prealloc` linters, `usetesting.os-setenv: true`, the `afero.*` forbidigo rule, the additional revive/paralleltest exclusions, and the `third_party$ | builtin$ | examples$` path lists for both `linters` and `formatters`.
- Dropped linters merged into `staticcheck` (`gosimple`, `stylecheck`) and the now-always-on `typecheck`.

## Code cleanups
- `kv/module.go`: `map[string]interface{}` -> `map[string]any` (`modernize`).
- `kv/store/{disk,memory}_benchmark_test.go`: `for i := 0; i < N; i++` -> `for i := range N` (`modernize`).
- `kv/store/disk_test.go`: dropped legacy `// +build !windows` line; `//go:build` was already present (`modernize`).
- Removed stale `//nolint:prealloc` in `kv/store/memory.go` and the now-redundant `gosec` entries in four `//nolint` directives that are covered by the test-file exclusion (`nolintlint`).

## Test plan
- [x] `golangci-lint config verify`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -timeout 300s ./...`
- [ ] CI passes on Ubuntu + Windows matrix