### PR TITLE
chore: bump go.etcd.io/bbolt to v1.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
-	go.etcd.io/bbolt v1.4.0
+	go.etcd.io/bbolt v1.4.3
 	go.k6.io/k6/v2 v2.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
-go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
+go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
+go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.k6.io/k6/v2 v2.0.0 h1:hcr8LXVjKS4ZiVdi6ouXoLBBms+sllF2hjr9VQyhrBY=
 go.k6.io/k6/v2 v2.0.0/go.mod h1:NQXqU7IQ3Ecj0sU2VNHbhdh7xIA+e0qmSCn2QrP7QO0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Summary
- Upgrades `go.etcd.io/bbolt` from v1.4.0 to v1.4.3 (latest stable; v1.5.0 is still rc).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -timeout 800s ./...`
- [x] `golangci-lint run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)