### PR TITLE
feat(store): add versioned atomic primitives

### DIFF
--- a/kv/module.go
+++ b/kv/module.go
@@ -9,6 +9,7 @@ package kv
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/grafana/sobek"
 	"go.k6.io/k6/v2/js/common"
@@ -21,6 +22,7 @@ type (
 	// RootModule is the global module instance that will create Client
 	// instances for each VU.
 	RootModule struct {
+		lock  sync.Mutex
 		store store.Store
 	}
 
@@ -69,6 +71,9 @@ func (mi *ModuleInstance) OpenKv(opts sobek.Value) *sobek.Object {
 		common.Throw(mi.vu.Runtime(), err)
 		return nil
 	}
+
+	mi.rm.lock.Lock()
+	defer mi.rm.lock.Unlock()
 
 	if mi.rm.store == nil {
 		// Create the base store based on the backend option

--- a/kv/store/disk.go
+++ b/kv/store/disk.go
@@ -65,17 +65,17 @@ func (s *DiskStore) open() error {
 	}
 
 	err = handler.Update(func(tx *bolt.Tx) error {
-		_, bucketErr := tx.CreateBucketIfNotExists([]byte(DefaultKvBucket))
+		bucket, bucketErr := tx.CreateBucketIfNotExists([]byte(DefaultKvBucket))
 		if bucketErr != nil {
 			return fmt.Errorf("failed to create internal bucket: %w", bucketErr)
 		}
 
-		_, bucketErr = tx.CreateBucketIfNotExists([]byte(DefaultKvVersionBucket))
+		versions, bucketErr := tx.CreateBucketIfNotExists([]byte(DefaultKvVersionBucket))
 		if bucketErr != nil {
 			return fmt.Errorf("failed to create internal versions bucket: %w", bucketErr)
 		}
 
-		return nil
+		return backfillVersionstamps(tx, bucket, versions)
 	})
 	if err != nil {
 		return err
@@ -495,6 +495,36 @@ func deleteDiskMutation(bucket, versions *bolt.Bucket, key string) error {
 
 func formatDiskVersionstamp(tx *bolt.Tx) string {
 	return fmt.Sprintf("%020d", tx.ID())
+}
+
+// backfillVersionstamps assigns a versionstamp to every key written by a
+// pre-versionstamp release. Such keys live in the data bucket with no entry in
+// the versions bucket; left untouched they would read back as absent and an
+// atomic absent-check would match a key that actually holds a value. Keys that
+// already carry a versionstamp are left untouched, so this is a no-op once a
+// store has been migrated.
+func backfillVersionstamps(tx *bolt.Tx, bucket, versions *bolt.Bucket) error {
+	var missing [][]byte
+	err := bucket.ForEach(func(k, _ []byte) error {
+		if versions.Get(k) == nil {
+			// ForEach reuses the key slice across iterations; copy it.
+			missing = append(missing, append([]byte(nil), k...))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	versionstamp := []byte(formatDiskVersionstamp(tx))
+	for _, key := range missing {
+		if err := versions.Put(key, versionstamp); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Close closes the disk store.

--- a/kv/store/disk.go
+++ b/kv/store/disk.go
@@ -11,12 +11,13 @@ import (
 
 // DiskStore is a key-value store that uses a BoltDB database on disk.
 type DiskStore struct {
-	path     string
-	handle   *bolt.DB
-	bucket   []byte
-	opened   atomic.Bool
-	refCount atomic.Int64
-	lock     sync.Mutex
+	path          string
+	handle        *bolt.DB
+	bucket        []byte
+	versionBucket []byte
+	opened        atomic.Bool
+	refCount      atomic.Int64
+	lock          sync.Mutex
 }
 
 const (
@@ -25,6 +26,9 @@ const (
 
 	// DefaultKvBucket is the default bucket name for the KV store
 	DefaultKvBucket = "k6"
+
+	// DefaultKvVersionBucket is the default bucket name for per-key versionstamps.
+	DefaultKvVersionBucket = "k6_versions"
 )
 
 // NewDiskStore creates a new DiskStore instance.
@@ -66,6 +70,11 @@ func (s *DiskStore) open() error {
 			return fmt.Errorf("failed to create internal bucket: %w", bucketErr)
 		}
 
+		_, bucketErr = tx.CreateBucketIfNotExists([]byte(DefaultKvVersionBucket))
+		if bucketErr != nil {
+			return fmt.Errorf("failed to create internal versions bucket: %w", bucketErr)
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -74,6 +83,7 @@ func (s *DiskStore) open() error {
 
 	s.handle = handler
 	s.bucket = []byte(DefaultKvBucket)
+	s.versionBucket = []byte(DefaultKvVersionBucket)
 	s.opened.Store(true)
 	s.refCount.Add(1)
 
@@ -96,7 +106,7 @@ func (s *DiskStore) Get(key string) (any, error) {
 			return fmt.Errorf("bucket %s not found", s.bucket)
 		}
 
-		value = bucket.Get([]byte(key))
+		value = cloneBytes(bucket.Get([]byte(key)))
 		return nil
 	})
 	if err != nil {
@@ -111,6 +121,75 @@ func (s *DiskStore) Get(key string) (any, error) {
 	return value, nil
 }
 
+// GetEntry returns the value and versionstamp for a key.
+func (s *DiskStore) GetEntry(key string) (Entry, error) {
+	if err := s.open(); err != nil {
+		return Entry{}, fmt.Errorf("failed to open disk store: %w", err)
+	}
+
+	entry := Entry{Key: key}
+	err := s.handle.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(s.bucket)
+		versions := tx.Bucket(s.versionBucket)
+		if bucket == nil {
+			return fmt.Errorf("bucket %s not found", s.bucket)
+		}
+		if versions == nil {
+			return fmt.Errorf("bucket %s not found", s.versionBucket)
+		}
+
+		value := bucket.Get([]byte(key))
+		if value == nil {
+			return nil
+		}
+
+		entry.Value = cloneBytes(value)
+		entry.Versionstamp = string(versions.Get([]byte(key)))
+		return nil
+	})
+	if err != nil {
+		return Entry{}, fmt.Errorf("unable to get entry from disk store: %w", err)
+	}
+
+	return entry, nil
+}
+
+// GetMany returns entries for the given keys in input order.
+func (s *DiskStore) GetMany(keys []string) ([]Entry, error) {
+	if err := s.open(); err != nil {
+		return nil, fmt.Errorf("failed to open disk store: %w", err)
+	}
+
+	entries := make([]Entry, len(keys))
+	err := s.handle.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(s.bucket)
+		versions := tx.Bucket(s.versionBucket)
+		if bucket == nil {
+			return fmt.Errorf("bucket %s not found", s.bucket)
+		}
+		if versions == nil {
+			return fmt.Errorf("bucket %s not found", s.versionBucket)
+		}
+
+		for i, key := range keys {
+			entries[i] = Entry{Key: key}
+			value := bucket.Get([]byte(key))
+			if value == nil {
+				continue
+			}
+			entries[i].Value = cloneBytes(value)
+			entries[i].Versionstamp = string(versions.Get([]byte(key)))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get entries from disk store: %w", err)
+	}
+
+	return entries, nil
+}
+
 // Set sets a value in the disk store.
 func (s *DiskStore) Set(key string, value any) error {
 	// Ensure the store is open
@@ -118,25 +197,27 @@ func (s *DiskStore) Set(key string, value any) error {
 		return fmt.Errorf("failed to open disk store: %w", err)
 	}
 
-	// Convert value to bytes if it's not already
-	var valueBytes []byte
-	switch v := value.(type) {
-	case []byte:
-		valueBytes = v
-	case string:
-		valueBytes = []byte(v)
-	default:
-		return fmt.Errorf("unsupported value type for disk store: %T", value)
+	valueBytes, err := bytesFromValue(value, "disk store")
+	if err != nil {
+		return err
 	}
 
 	// Update the value in the database within a BoltDB transaction
-	err := s.handle.Update(func(tx *bolt.Tx) error {
+	err = s.handle.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(s.bucket)
+		versions := tx.Bucket(s.versionBucket)
 		if bucket == nil {
 			return fmt.Errorf("bucket not found")
 		}
+		if versions == nil {
+			return fmt.Errorf("versions bucket not found")
+		}
 
-		return bucket.Put([]byte(key), valueBytes)
+		if err := bucket.Put([]byte(key), valueBytes); err != nil {
+			return err
+		}
+
+		return versions.Put([]byte(key), []byte(formatDiskVersionstamp(tx)))
 	})
 	if err != nil {
 		return fmt.Errorf("unable to insert value into disk store: %w", err)
@@ -154,11 +235,19 @@ func (s *DiskStore) Delete(key string) error {
 
 	err := s.handle.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(s.bucket)
+		versions := tx.Bucket(s.versionBucket)
 		if bucket == nil {
 			return fmt.Errorf("bucket %s not found", s.bucket)
 		}
+		if versions == nil {
+			return fmt.Errorf("bucket %s not found", s.versionBucket)
+		}
 
-		return bucket.Delete([]byte(key))
+		if err := bucket.Delete([]byte(key)); err != nil {
+			return err
+		}
+
+		return versions.Delete([]byte(key))
 	})
 	if err != nil {
 		return fmt.Errorf("unable to delete value from disk store: %w", err)
@@ -200,12 +289,22 @@ func (s *DiskStore) Clear() error {
 
 	err := s.handle.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(s.bucket)
+		versions := tx.Bucket(s.versionBucket)
 		if bucket == nil {
 			return fmt.Errorf("bucket %s not found", s.bucket)
 		}
+		if versions == nil {
+			return fmt.Errorf("bucket %s not found", s.versionBucket)
+		}
 
-		return bucket.ForEach(func(k, _ []byte) error {
+		if err := bucket.ForEach(func(k, _ []byte) error {
 			return bucket.Delete(k)
+		}); err != nil {
+			return err
+		}
+
+		return versions.ForEach(func(k, _ []byte) error {
+			return versions.Delete(k)
 		})
 	})
 	if err != nil {
@@ -226,8 +325,12 @@ func (s *DiskStore) Size() (int64, error) {
 
 	err := s.handle.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(s.bucket)
+		versions := tx.Bucket(s.versionBucket)
 		if bucket == nil {
 			return fmt.Errorf("bucket %s not found", s.bucket)
+		}
+		if versions == nil {
+			return fmt.Errorf("bucket %s not found", s.versionBucket)
 		}
 
 		size = int64(bucket.Stats().KeyN)
@@ -252,8 +355,12 @@ func (s *DiskStore) List(prefix string, limit int64) ([]Entry, error) {
 
 	err := s.handle.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(s.bucket)
+		versions := tx.Bucket(s.versionBucket)
 		if bucket == nil {
 			return fmt.Errorf("bucket %s not found", s.bucket)
+		}
+		if versions == nil {
+			return fmt.Errorf("bucket %s not found", s.versionBucket)
 		}
 
 		var count int64
@@ -271,8 +378,9 @@ func (s *DiskStore) List(prefix string, limit int64) ([]Entry, error) {
 			}
 
 			entries = append(entries, Entry{
-				Key:   key,
-				Value: v,
+				Key:          key,
+				Value:        cloneBytes(v),
+				Versionstamp: string(versions.Get(k)),
 			})
 			count++
 		}
@@ -284,6 +392,109 @@ func (s *DiskStore) List(prefix string, limit int64) ([]Entry, error) {
 	}
 
 	return entries, nil
+}
+
+// AtomicCommit commits checks and mutations as a single atomic operation.
+func (s *DiskStore) AtomicCommit(checks []Check, mutations []Mutation) (CommitResult, error) {
+	if err := s.open(); err != nil {
+		return CommitResult{}, fmt.Errorf("failed to open disk store: %w", err)
+	}
+
+	var result CommitResult
+	err := s.handle.Update(func(tx *bolt.Tx) error {
+		bucket, versions, bucketErr := s.atomicBuckets(tx)
+		if bucketErr != nil {
+			return bucketErr
+		}
+
+		if !checksMatch(versions, checks) {
+			result = CommitResult{Ok: false}
+			return nil
+		}
+
+		versionstamp := formatDiskVersionstamp(tx)
+		if mutationErr := applyDiskMutations(bucket, versions, versionstamp, mutations); mutationErr != nil {
+			return mutationErr
+		}
+		result = CommitResult{Ok: true, Versionstamp: versionstamp}
+
+		return nil
+	})
+	if err != nil {
+		return CommitResult{}, fmt.Errorf("unable to commit atomic operation to disk store: %w", err)
+	}
+
+	return result, nil
+}
+
+func (s *DiskStore) atomicBuckets(tx *bolt.Tx) (*bolt.Bucket, *bolt.Bucket, error) {
+	bucket := tx.Bucket(s.bucket)
+	if bucket == nil {
+		return nil, nil, fmt.Errorf("bucket %s not found", s.bucket)
+	}
+
+	versions := tx.Bucket(s.versionBucket)
+	if versions == nil {
+		return nil, nil, fmt.Errorf("bucket %s not found", s.versionBucket)
+	}
+
+	return bucket, versions, nil
+}
+
+func checksMatch(versions *bolt.Bucket, checks []Check) bool {
+	for _, check := range checks {
+		current := string(versions.Get([]byte(check.Key)))
+		if current != check.Versionstamp {
+			return false
+		}
+	}
+
+	return true
+}
+
+func applyDiskMutations(bucket, versions *bolt.Bucket, versionstamp string, mutations []Mutation) error {
+	for _, mutation := range mutations {
+		if err := applyDiskMutation(bucket, versions, versionstamp, mutation); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func applyDiskMutation(bucket, versions *bolt.Bucket, versionstamp string, mutation Mutation) error {
+	switch mutation.Type {
+	case MutationSet:
+		return setDiskMutation(bucket, versions, versionstamp, mutation)
+	case MutationDelete:
+		return deleteDiskMutation(bucket, versions, mutation.Key)
+	default:
+		return fmt.Errorf("unsupported mutation type: %s", mutation.Type)
+	}
+}
+
+func setDiskMutation(bucket, versions *bolt.Bucket, versionstamp string, mutation Mutation) error {
+	valueBytes, err := bytesFromValue(mutation.Value, "disk store")
+	if err != nil {
+		return err
+	}
+	if err := bucket.Put([]byte(mutation.Key), valueBytes); err != nil {
+		return err
+	}
+
+	return versions.Put([]byte(mutation.Key), []byte(versionstamp))
+}
+
+func deleteDiskMutation(bucket, versions *bolt.Bucket, key string) error {
+	if err := bucket.Delete([]byte(key)); err != nil {
+		return err
+	}
+
+	return versions.Delete([]byte(key))
+}
+
+func formatDiskVersionstamp(tx *bolt.Tx) string {
+	return fmt.Sprintf("%020d", tx.ID())
 }
 
 // Close closes the disk store.

--- a/kv/store/disk.go
+++ b/kv/store/disk.go
@@ -145,6 +145,7 @@ func (s *DiskStore) GetEntry(key string) (Entry, error) {
 
 		entry.Value = cloneBytes(value)
 		entry.Versionstamp = string(versions.Get([]byte(key)))
+		entry.Found = true
 		return nil
 	})
 	if err != nil {
@@ -179,6 +180,7 @@ func (s *DiskStore) GetMany(keys []string) ([]Entry, error) {
 			}
 			entries[i].Value = cloneBytes(value)
 			entries[i].Versionstamp = string(versions.Get([]byte(key)))
+			entries[i].Found = true
 		}
 
 		return nil
@@ -381,6 +383,7 @@ func (s *DiskStore) List(prefix string, limit int64) ([]Entry, error) {
 				Key:          key,
 				Value:        cloneBytes(v),
 				Versionstamp: string(versions.Get(k)),
+				Found:        true,
 			})
 			count++
 		}

--- a/kv/store/disk_test.go
+++ b/kv/store/disk_test.go
@@ -846,3 +846,224 @@ func TestDiskStore_TableDriven(t *testing.T) {
 		})
 	}
 }
+
+func newTempDiskStore(t *testing.T) *DiskStore {
+	t.Helper()
+
+	// setupTempDiskStore places the file under t.TempDir(), which is removed
+	// automatically when the test finishes, so no explicit cleanup is needed.
+	store := NewDiskStore()
+	store.path = setupTempDiskStore(t)
+	t.Cleanup(func() { _ = store.Close() })
+
+	return store
+}
+
+func TestDiskStore_GetEntry(t *testing.T) {
+	t.Parallel()
+
+	store := newTempDiskStore(t)
+
+	// Absent key: Found is false, with a nil value and empty versionstamp.
+	absent, err := store.GetEntry("missing")
+	if err != nil {
+		t.Fatalf("GetEntry() on a missing key returned an error: %v", err)
+	}
+	if absent.Found {
+		t.Fatal("GetEntry() reported a missing key as present")
+	}
+	if absent.Value != nil {
+		t.Fatalf("GetEntry() on a missing key returned a non-nil value: %#v", absent.Value)
+	}
+	if absent.Versionstamp != "" {
+		t.Fatalf("GetEntry() on a missing key returned a versionstamp: %q", absent.Versionstamp)
+	}
+
+	// Present key: Found is true, with the stored value and a versionstamp.
+	if err := store.Set("present", []byte("value")); err != nil {
+		t.Fatalf("Set() returned an error: %v", err)
+	}
+	entry, err := store.GetEntry("present")
+	if err != nil {
+		t.Fatalf("GetEntry() on a present key returned an error: %v", err)
+	}
+	if !entry.Found {
+		t.Fatal("GetEntry() reported a present key as missing")
+	}
+	if string(entry.Value.([]byte)) != "value" {
+		t.Fatalf("GetEntry() returned unexpected value, got %#v, want %q", entry.Value, "value")
+	}
+	if entry.Versionstamp == "" {
+		t.Fatal("GetEntry() returned an empty versionstamp for a present key")
+	}
+}
+
+func TestDiskStore_GetMany(t *testing.T) {
+	t.Parallel()
+
+	store := newTempDiskStore(t)
+
+	if err := store.Set("a", []byte("1")); err != nil {
+		t.Fatalf("Set() returned an error: %v", err)
+	}
+	if err := store.Set("c", []byte("3")); err != nil {
+		t.Fatalf("Set() returned an error: %v", err)
+	}
+
+	// Order must match the input keys, with a placeholder for the absent key.
+	entries, err := store.GetMany([]string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("GetMany() returned an error: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("GetMany() returned %d entries, want 3", len(entries))
+	}
+
+	wantKeys := []string{"a", "b", "c"}
+	for i, want := range wantKeys {
+		if entries[i].Key != want {
+			t.Fatalf("GetMany() entry %d has key %q, want %q", i, entries[i].Key, want)
+		}
+	}
+
+	if !entries[0].Found || string(entries[0].Value.([]byte)) != "1" {
+		t.Fatalf("GetMany() entry for %q is wrong: %+v", "a", entries[0])
+	}
+	if entries[1].Found {
+		t.Fatalf("GetMany() reported absent key %q as present: %+v", "b", entries[1])
+	}
+	if !entries[2].Found || string(entries[2].Value.([]byte)) != "3" {
+		t.Fatalf("GetMany() entry for %q is wrong: %+v", "c", entries[2])
+	}
+}
+
+func TestDiskStore_VersionstampMonotonic(t *testing.T) {
+	t.Parallel()
+
+	store := newTempDiskStore(t)
+
+	if err := store.Set("k", []byte("v1")); err != nil {
+		t.Fatalf("Set() returned an error: %v", err)
+	}
+	first, err := store.GetEntry("k")
+	if err != nil {
+		t.Fatalf("GetEntry() returned an error: %v", err)
+	}
+
+	if err := store.Set("k", []byte("v2")); err != nil {
+		t.Fatalf("Set() returned an error: %v", err)
+	}
+	second, err := store.GetEntry("k")
+	if err != nil {
+		t.Fatalf("GetEntry() returned an error: %v", err)
+	}
+
+	// Versionstamps are fixed-width, so lexical order matches write order.
+	if second.Versionstamp <= first.Versionstamp {
+		t.Fatalf("versionstamp did not advance: first=%q second=%q", first.Versionstamp, second.Versionstamp)
+	}
+}
+
+func TestDiskStore_AtomicCommit(t *testing.T) {
+	t.Parallel()
+
+	store := newTempDiskStore(t)
+
+	// A commit whose checks all hold applies its mutations and reports a versionstamp.
+	result, err := store.AtomicCommit(
+		[]Check{{Key: "k"}}, // expect "k" absent
+		[]Mutation{{Type: MutationSet, Key: "k", Value: []byte("v")}},
+	)
+	if err != nil {
+		t.Fatalf("AtomicCommit() returned an error: %v", err)
+	}
+	if !result.Ok {
+		t.Fatal("AtomicCommit() with a satisfied check did not commit")
+	}
+	if result.Versionstamp == "" {
+		t.Fatal("AtomicCommit() committed without returning a versionstamp")
+	}
+
+	entry, err := store.GetEntry("k")
+	if err != nil {
+		t.Fatalf("GetEntry() returned an error: %v", err)
+	}
+	if !entry.Found || string(entry.Value.([]byte)) != "v" {
+		t.Fatalf("AtomicCommit() did not persist the mutation: %+v", entry)
+	}
+	if entry.Versionstamp != result.Versionstamp {
+		t.Fatalf("stored versionstamp %q does not match commit result %q", entry.Versionstamp, result.Versionstamp)
+	}
+
+	// A commit whose check no longer holds is rejected and changes nothing.
+	rejected, err := store.AtomicCommit(
+		[]Check{{Key: "k"}}, // expect "k" absent, but it now holds "v"
+		[]Mutation{{Type: MutationSet, Key: "k", Value: []byte("other")}},
+	)
+	if err != nil {
+		t.Fatalf("AtomicCommit() returned an error: %v", err)
+	}
+	if rejected.Ok {
+		t.Fatal("AtomicCommit() applied mutations despite a failed check")
+	}
+
+	unchanged, err := store.GetEntry("k")
+	if err != nil {
+		t.Fatalf("GetEntry() returned an error: %v", err)
+	}
+	if string(unchanged.Value.([]byte)) != "v" {
+		t.Fatalf("rejected commit mutated the store: %+v", unchanged)
+	}
+
+	// A delete mutation behind a matching versionstamp check removes the key.
+	deleted, err := store.AtomicCommit(
+		[]Check{{Key: "k", Versionstamp: unchanged.Versionstamp}},
+		[]Mutation{{Type: MutationDelete, Key: "k"}},
+	)
+	if err != nil {
+		t.Fatalf("AtomicCommit() returned an error: %v", err)
+	}
+	if !deleted.Ok {
+		t.Fatal("AtomicCommit() with a matching versionstamp check did not commit")
+	}
+
+	gone, err := store.GetEntry("k")
+	if err != nil {
+		t.Fatalf("GetEntry() returned an error: %v", err)
+	}
+	if gone.Found {
+		t.Fatal("AtomicCommit() delete mutation left the key in place")
+	}
+}
+
+func TestDiskStore_AtomicCommitConcurrentAbsentCheck(t *testing.T) {
+	t.Parallel()
+
+	store := newTempDiskStore(t)
+
+	const goroutines = 20
+	results := make(chan CommitResult, goroutines)
+	for range goroutines {
+		go func() {
+			result, err := store.AtomicCommit(
+				[]Check{{Key: "lock"}},
+				[]Mutation{{Type: MutationSet, Key: "lock", Value: []byte("owner")}},
+			)
+			if err != nil {
+				t.Errorf("AtomicCommit() returned error: %v", err)
+				return
+			}
+			results <- result
+		}()
+	}
+
+	var wins int
+	for range goroutines {
+		if result := <-results; result.Ok {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("AtomicCommit() allowed %d absent-check winners, want 1", wins)
+	}
+}

--- a/kv/store/disk_test.go
+++ b/kv/store/disk_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	bolt "go.etcd.io/bbolt"
 )
 
 func TestNewDiskStore(t *testing.T) {
@@ -481,6 +483,71 @@ func TestDiskStore_RefCount(t *testing.T) {
 }
 
 // Helper function to set up a temporary disk store for testing
+// seedLegacyDiskValue writes a value the way a pre-versionstamp release would:
+// straight into the data bucket, with no matching entry in the versions bucket.
+func seedLegacyDiskValue(t *testing.T, path, key string, value []byte) {
+	t.Helper()
+
+	db, err := bolt.Open(path, 0o600, nil)
+	if err != nil {
+		t.Fatalf("failed to open legacy bolt db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		bucket, bucketErr := tx.CreateBucketIfNotExists([]byte(DefaultKvBucket))
+		if bucketErr != nil {
+			return bucketErr
+		}
+
+		return bucket.Put([]byte(key), value)
+	})
+	if err != nil {
+		t.Fatalf("failed to seed legacy data: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close legacy bolt db: %v", err)
+	}
+}
+
+// TestDiskStore_LegacyVersionstampBackfill verifies that values written by a
+// pre-versionstamp release stay readable after the upgrade and are no longer
+// mistaken for absent keys by an atomic absent-check.
+func TestDiskStore_LegacyVersionstampBackfill(t *testing.T) {
+	t.Parallel()
+
+	tempFile := setupTempDiskStore(t)
+	defer os.Remove(tempFile) //nolint:errcheck,forbidigo
+
+	seedLegacyDiskValue(t, tempFile, "legacy", []byte(`"value"`))
+
+	disk := NewDiskStore()
+	disk.path = tempFile
+	store := NewSerializedStore(disk, NewJSONSerializer())
+	t.Cleanup(func() { _ = store.Close() })
+
+	// The legacy value must remain readable after the upgrade.
+	value, err := store.Get("legacy")
+	if err != nil {
+		t.Fatalf("Get() on legacy key returned an error: %v", err)
+	}
+	if value != "value" {
+		t.Fatalf("Get() returned unexpected legacy value, got %#v, want %q", value, "value")
+	}
+
+	// An absent-check must not match a key that already holds a value.
+	result, err := disk.AtomicCommit(
+		[]Check{{Key: "legacy"}},
+		[]Mutation{{Type: MutationSet, Key: "legacy", Value: []byte("overwritten")}},
+	)
+	if err != nil {
+		t.Fatalf("AtomicCommit() returned an error: %v", err)
+	}
+	if result.Ok {
+		t.Fatal("AtomicCommit() absent-check matched a present legacy key")
+	}
+}
+
 func setupTempDiskStore(t *testing.T) string {
 	// Create a temporary file
 	tempFile, err := os.CreateTemp(t.TempDir(), "diskstore-test-*.db") //nolint:forbidigo

--- a/kv/store/memory.go
+++ b/kv/store/memory.go
@@ -52,6 +52,7 @@ func (s *MemoryStore) GetEntry(key string) (Entry, error) {
 		Key:          key,
 		Value:        cloneBytes(value),
 		Versionstamp: s.versions[key],
+		Found:        true,
 	}, nil
 }
 
@@ -66,6 +67,7 @@ func (s *MemoryStore) GetMany(keys []string) ([]Entry, error) {
 		if value, ok := s.container[key]; ok {
 			entries[i].Value = cloneBytes(value)
 			entries[i].Versionstamp = s.versions[key]
+			entries[i].Found = true
 		}
 	}
 
@@ -154,6 +156,7 @@ func (s *MemoryStore) List(prefix string, limit int64) ([]Entry, error) {
 			Key:          k,
 			Value:        cloneBytes(s.container[k]),
 			Versionstamp: s.versions[k],
+			Found:        true,
 		})
 		count++
 	}

--- a/kv/store/memory.go
+++ b/kv/store/memory.go
@@ -11,6 +11,8 @@ import (
 type MemoryStore struct {
 	mu        sync.RWMutex
 	container map[string][]byte
+	versions  map[string]string
+	version   uint64
 }
 
 // NewMemoryStore creates a new MemoryStore.
@@ -18,6 +20,7 @@ func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
 		mu:        sync.RWMutex{},
 		container: map[string][]byte{},
+		versions:  map[string]string{},
 	}
 }
 
@@ -32,7 +35,41 @@ func (s *MemoryStore) Get(key string) (any, error) {
 	}
 
 	// Return the raw bytes - serialization will be handled by the SerializedStore wrapper
-	return value, nil
+	return cloneBytes(value), nil
+}
+
+// GetEntry returns the value and versionstamp for a given key.
+func (s *MemoryStore) GetEntry(key string) (Entry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	value, ok := s.container[key]
+	if !ok {
+		return Entry{Key: key}, nil
+	}
+
+	return Entry{
+		Key:          key,
+		Value:        cloneBytes(value),
+		Versionstamp: s.versions[key],
+	}, nil
+}
+
+// GetMany returns entries for the given keys in input order.
+func (s *MemoryStore) GetMany(keys []string) ([]Entry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries := make([]Entry, len(keys))
+	for i, key := range keys {
+		entries[i] = Entry{Key: key}
+		if value, ok := s.container[key]; ok {
+			entries[i].Value = cloneBytes(value)
+			entries[i].Versionstamp = s.versions[key]
+		}
+	}
+
+	return entries, nil
 }
 
 // Set sets the value for a given key.
@@ -51,7 +88,8 @@ func (s *MemoryStore) Set(key string, value any) error {
 		return fmt.Errorf("unsupported value type for memory store: %T", value)
 	}
 
-	s.container[key] = valueBytes
+	s.container[key] = cloneBytes(valueBytes)
+	s.versions[key] = s.nextVersionstamp()
 	return nil
 }
 
@@ -60,6 +98,7 @@ func (s *MemoryStore) Delete(key string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.container, key)
+	delete(s.versions, key)
 	return nil
 }
 
@@ -76,6 +115,7 @@ func (s *MemoryStore) Clear() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.container = map[string][]byte{}
+	s.versions = map[string]string{}
 	return nil
 }
 
@@ -111,8 +151,9 @@ func (s *MemoryStore) List(prefix string, limit int64) ([]Entry, error) {
 		}
 
 		entries = append(entries, Entry{
-			Key:   k,
-			Value: s.container[k],
+			Key:          k,
+			Value:        cloneBytes(s.container[k]),
+			Versionstamp: s.versions[k],
 		})
 		count++
 	}
@@ -120,9 +161,61 @@ func (s *MemoryStore) List(prefix string, limit int64) ([]Entry, error) {
 	return entries, nil
 }
 
+// AtomicCommit commits checks and mutations as a single atomic operation.
+func (s *MemoryStore) AtomicCommit(checks []Check, mutations []Mutation) (CommitResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, check := range checks {
+		if s.versions[check.Key] != check.Versionstamp {
+			return CommitResult{Ok: false}, nil
+		}
+	}
+
+	versionstamp := s.nextVersionstamp()
+	for _, mutation := range mutations {
+		switch mutation.Type {
+		case MutationSet:
+			valueBytes, err := bytesFromValue(mutation.Value, "memory store")
+			if err != nil {
+				return CommitResult{}, err
+			}
+			s.container[mutation.Key] = cloneBytes(valueBytes)
+			s.versions[mutation.Key] = versionstamp
+		case MutationDelete:
+			delete(s.container, mutation.Key)
+			delete(s.versions, mutation.Key)
+		default:
+			return CommitResult{}, fmt.Errorf("unsupported mutation type: %s", mutation.Type)
+		}
+	}
+
+	return CommitResult{Ok: true, Versionstamp: versionstamp}, nil
+}
+
 // Close closes the store.
 //
 // This is a no-op for the MemoryStore.
 func (s *MemoryStore) Close() error {
 	return nil
+}
+
+func (s *MemoryStore) nextVersionstamp() string {
+	s.version++
+	return formatVersionstamp(s.version)
+}
+
+func bytesFromValue(value any, storeName string) ([]byte, error) {
+	switch v := value.(type) {
+	case []byte:
+		return v, nil
+	case string:
+		return []byte(v), nil
+	default:
+		return nil, fmt.Errorf("unsupported value type for %s: %T", storeName, value)
+	}
+}
+
+func cloneBytes(value []byte) []byte {
+	return append([]byte(nil), value...)
 }

--- a/kv/store/memory_test.go
+++ b/kv/store/memory_test.go
@@ -314,6 +314,72 @@ func TestMemoryStore_Concurrency(t *testing.T) {
 	// If we got here without deadlocking, the test passes
 }
 
+func TestMemoryStore_AtomicCommitConcurrentAbsentCheck(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore()
+
+	const goroutines = 20
+	results := make(chan CommitResult, goroutines)
+	for range make([]struct{}, goroutines) {
+		go func() {
+			result, err := store.AtomicCommit(
+				[]Check{{Key: "lock"}},
+				[]Mutation{{Type: MutationSet, Key: "lock", Value: []byte("owner")}},
+			)
+			if err != nil {
+				t.Errorf("AtomicCommit() returned error: %v", err)
+				return
+			}
+			results <- result
+		}()
+	}
+
+	var wins int
+	for range make([]struct{}, goroutines) {
+		result := <-results
+		if result.Ok {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("AtomicCommit() allowed %d absent-check winners, want 1", wins)
+	}
+}
+
+func TestSerializedStore_AtomicCommitConcurrentAbsentCheck(t *testing.T) {
+	t.Parallel()
+
+	store := NewSerializedStore(NewMemoryStore(), NewJSONSerializer())
+
+	const goroutines = 20
+	results := make(chan CommitResult, goroutines)
+	for range make([]struct{}, goroutines) {
+		go func() {
+			result, err := store.AtomicCommit(
+				[]Check{{Key: "lock"}},
+				[]Mutation{{Type: MutationSet, Key: "lock", Value: "owner"}},
+			)
+			if err != nil {
+				t.Errorf("AtomicCommit() returned error: %v", err)
+				return
+			}
+			results <- result
+		}()
+	}
+
+	var wins int
+	for range make([]struct{}, goroutines) {
+		result := <-results
+		if result.Ok {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("AtomicCommit() allowed %d absent-check winners, want 1", wins)
+	}
+}
+
 // TestMemoryStore_TableDemonstrates demonstrates the table-driven testing approach
 func TestMemoryStore_TableDriven(t *testing.T) {
 	t.Parallel()

--- a/kv/store/serialized_store.go
+++ b/kv/store/serialized_store.go
@@ -25,7 +25,7 @@ func (s *SerializedStore) Get(key string) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	if entry.Versionstamp == "" {
+	if !entry.Found {
 		return nil, fmt.Errorf("key %s not found", key)
 	}
 
@@ -38,7 +38,7 @@ func (s *SerializedStore) GetEntry(key string) (Entry, error) {
 	if err != nil {
 		return Entry{}, err
 	}
-	if entry.Versionstamp == "" {
+	if !entry.Found {
 		return entry, nil
 	}
 
@@ -131,7 +131,7 @@ func (s *SerializedStore) AtomicCommit(checks []Check, mutations []Mutation) (Co
 func (s *SerializedStore) deserializeEntries(rawEntries []Entry) ([]Entry, error) {
 	entries := make([]Entry, len(rawEntries))
 	for i, entry := range rawEntries {
-		if entry.Versionstamp == "" {
+		if !entry.Found {
 			entries[i] = entry
 			continue
 		}

--- a/kv/store/serialized_store.go
+++ b/kv/store/serialized_store.go
@@ -21,24 +21,43 @@ func NewSerializedStore(store Store, serializer Serializer) *SerializedStore {
 
 // Get retrieves a value from the store and deserializes it.
 func (s *SerializedStore) Get(key string) (any, error) {
-	// Get the raw value from the store
-	rawValue, err := s.store.Get(key)
+	entry, err := s.store.GetEntry(key)
+	if err != nil {
+		return nil, err
+	}
+	if entry.Versionstamp == "" {
+		return nil, fmt.Errorf("key %s not found", key)
+	}
+
+	return s.deserializeValue(entry.Value)
+}
+
+// GetEntry retrieves an entry from the store and deserializes its value.
+func (s *SerializedStore) GetEntry(key string) (Entry, error) {
+	entry, err := s.store.GetEntry(key)
+	if err != nil {
+		return Entry{}, err
+	}
+	if entry.Versionstamp == "" {
+		return entry, nil
+	}
+
+	entry.Value, err = s.deserializeValue(entry.Value)
+	if err != nil {
+		return Entry{}, fmt.Errorf("failed to deserialize value for key %s: %w", entry.Key, err)
+	}
+
+	return entry, nil
+}
+
+// GetMany retrieves entries from the store and deserializes their values.
+func (s *SerializedStore) GetMany(keys []string) ([]Entry, error) {
+	entries, err := s.store.GetMany(keys)
 	if err != nil {
 		return nil, err
 	}
 
-	// Handle string values from stores that don't use byte slices
-	if strValue, ok := rawValue.(string); ok {
-		return s.serializer.Deserialize([]byte(strValue))
-	}
-
-	// Handle byte slice values
-	if byteValue, ok := rawValue.([]byte); ok {
-		return s.serializer.Deserialize(byteValue)
-	}
-
-	// If the value is already deserialized (e.g., from memory store)
-	return rawValue, nil
+	return s.deserializeEntries(entries)
 }
 
 // Set serializes a value and stores it.
@@ -82,36 +101,63 @@ func (s *SerializedStore) List(prefix string, limit int64) ([]Entry, error) {
 	}
 
 	// Deserialize each entry's value
+	return s.deserializeEntries(rawEntries)
+}
+
+// Close closes the underlying store.
+func (s *SerializedStore) Close() error {
+	return s.store.Close()
+}
+
+// AtomicCommit serializes set mutations and commits them to the underlying store.
+func (s *SerializedStore) AtomicCommit(checks []Check, mutations []Mutation) (CommitResult, error) {
+	serializedMutations := make([]Mutation, len(mutations))
+	for i, mutation := range mutations {
+		serializedMutations[i] = mutation
+		if mutation.Type != MutationSet {
+			continue
+		}
+
+		serializedValue, err := s.serializer.Serialize(mutation.Value)
+		if err != nil {
+			return CommitResult{}, fmt.Errorf("failed to serialize value for key %s: %w", mutation.Key, err)
+		}
+		serializedMutations[i].Value = serializedValue
+	}
+
+	return s.store.AtomicCommit(checks, serializedMutations)
+}
+
+func (s *SerializedStore) deserializeEntries(rawEntries []Entry) ([]Entry, error) {
 	entries := make([]Entry, len(rawEntries))
 	for i, entry := range rawEntries {
-		// Handle string values from stores that don't use byte slices
-		if strValue, ok := entry.Value.(string); ok {
-			deserializedValue, err := s.serializer.Deserialize([]byte(strValue))
-			if err != nil {
-				return nil, fmt.Errorf("failed to deserialize value for key %s: %w", entry.Key, err)
-			}
-			entries[i] = Entry{Key: entry.Key, Value: deserializedValue}
+		if entry.Versionstamp == "" {
+			entries[i] = entry
 			continue
 		}
 
-		// Handle byte slice values
-		if byteValue, ok := entry.Value.([]byte); ok {
-			deserializedValue, err := s.serializer.Deserialize(byteValue)
-			if err != nil {
-				return nil, fmt.Errorf("failed to deserialize value for key %s: %w", entry.Key, err)
-			}
-			entries[i] = Entry{Key: entry.Key, Value: deserializedValue}
-			continue
+		deserializedValue, err := s.deserializeValue(entry.Value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize value for key %s: %w", entry.Key, err)
 		}
-
-		// If the value is already deserialized (e.g., from memory store)
+		entry.Value = deserializedValue
 		entries[i] = entry
 	}
 
 	return entries, nil
 }
 
-// Close closes the underlying store.
-func (s *SerializedStore) Close() error {
-	return s.store.Close()
+func (s *SerializedStore) deserializeValue(rawValue any) (any, error) {
+	// Handle string values from stores that don't use byte slices
+	if strValue, ok := rawValue.(string); ok {
+		return s.serializer.Deserialize([]byte(strValue))
+	}
+
+	// Handle byte slice values
+	if byteValue, ok := rawValue.([]byte); ok {
+		return s.serializer.Deserialize(byteValue)
+	}
+
+	// If the value is already deserialized (e.g., from memory store)
+	return rawValue, nil
 }

--- a/kv/store/serialized_store_test.go
+++ b/kv/store/serialized_store_test.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// fixedEntryStore returns a single canned entry from GetEntry regardless of the
+// key. The embedded Store interface satisfies the rest of the contract; only
+// GetEntry is exercised by these tests, so the nil embed is never called.
+type fixedEntryStore struct {
+	Store
+	entry Entry
+}
+
+func (s fixedEntryStore) GetEntry(string) (Entry, error) {
+	return s.entry, nil
+}
+
+// TestSerializedStore_PresentEntryWithoutVersionstamp proves that presence is
+// read from Entry.Found, not from the versionstamp. A present value carrying no
+// versionstamp must still be returned rather than reported as missing.
+func TestSerializedStore_PresentEntryWithoutVersionstamp(t *testing.T) {
+	t.Parallel()
+
+	backend := fixedEntryStore{entry: Entry{Key: "key", Value: []byte(`"value"`), Found: true}}
+	store := NewSerializedStore(backend, NewJSONSerializer())
+
+	got, err := store.Get("key")
+	if err != nil {
+		t.Fatalf("Get() on a present unversioned entry returned an error: %v", err)
+	}
+	if got != "value" {
+		t.Fatalf("Get() returned unexpected value, got %#v, want %q", got, "value")
+	}
+}
+
+// TestSerializedStore_AbsentEntryWithVersionstamp proves the converse: an absent
+// entry must be reported as missing even if it carries a stale versionstamp, and
+// its value must never be deserialized.
+func TestSerializedStore_AbsentEntryWithVersionstamp(t *testing.T) {
+	t.Parallel()
+
+	backend := fixedEntryStore{entry: Entry{
+		Key:          "key",
+		Value:        []byte("not-valid-json"),
+		Versionstamp: "00000000000000000001",
+		Found:        false,
+	}}
+	store := NewSerializedStore(backend, NewJSONSerializer())
+
+	_, err := store.Get("key")
+	if err == nil {
+		t.Fatal("Get() on an absent entry should return an error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("Get() returned unexpected error, got %v, want a not-found error", err)
+	}
+}

--- a/kv/store/store.go
+++ b/kv/store/store.go
@@ -12,8 +12,8 @@ type Store interface {
 
 	// GetEntry returns the key's value and versionstamp.
 	//
-	// If the key does not exist, the returned entry has a nil value and an
-	// empty versionstamp.
+	// If the key does not exist, the returned entry has Found set to false,
+	// a nil value, and an empty versionstamp.
 	GetEntry(key string) (Entry, error)
 
 	// GetMany returns entries for keys in the same order as the input keys.
@@ -49,6 +49,10 @@ type Entry struct {
 	Key          string
 	Value        any
 	Versionstamp string
+
+	// Found reports whether the key exists in the store. It distinguishes a
+	// present key from an absent one without relying on the versionstamp.
+	Found bool
 }
 
 // Check represents a versionstamp precondition for an atomic commit.

--- a/kv/store/store.go
+++ b/kv/store/store.go
@@ -1,10 +1,23 @@
 // Package store provides a key-value store interface and implementations.
 package store
 
+import "fmt"
+
 // Store interface defines the operations for a key-value store.
+//
+//nolint:interfacebloat // Store is the backend contract shared by all KV implementations.
 type Store interface {
 	// Get returns the value of a key in the store.
 	Get(key string) (any, error)
+
+	// GetEntry returns the key's value and versionstamp.
+	//
+	// If the key does not exist, the returned entry has a nil value and an
+	// empty versionstamp.
+	GetEntry(key string) (Entry, error)
+
+	// GetMany returns entries for keys in the same order as the input keys.
+	GetMany(keys []string) ([]Entry, error)
 
 	// Set sets the value of a key in the store.
 	Set(key string, value any) error
@@ -26,10 +39,48 @@ type Store interface {
 
 	// Close closes the store.
 	Close() error
+
+	// AtomicCommit commits checks and mutations as a single atomic operation.
+	AtomicCommit(checks []Check, mutations []Mutation) (CommitResult, error)
 }
 
 // Entry represents a key-value pair in the store.
 type Entry struct {
+	Key          string
+	Value        any
+	Versionstamp string
+}
+
+// Check represents a versionstamp precondition for an atomic commit.
+type Check struct {
+	Key          string
+	Versionstamp string
+}
+
+// MutationType identifies the kind of mutation in an atomic commit.
+type MutationType string
+
+const (
+	// MutationSet sets the key to the provided value.
+	MutationSet MutationType = "set"
+
+	// MutationDelete deletes the key.
+	MutationDelete MutationType = "delete"
+)
+
+// Mutation represents a state change in an atomic commit.
+type Mutation struct {
+	Type  MutationType
 	Key   string
 	Value any
+}
+
+// CommitResult is returned from an atomic commit.
+type CommitResult struct {
+	Ok           bool
+	Versionstamp string
+}
+
+func formatVersionstamp(version uint64) string {
+	return fmt.Sprintf("%020d", version)
 }


### PR DESCRIPTION
Summary
- add versioned store entries, checks, mutations, and commit results
- implement atomic commits for memory and BoltDB backends
- preserve versionstamps through the serialized store wrapper
- add absent-check concurrency coverage at the store layer

Tests
- go test ./...
- go test -race ./...